### PR TITLE
Remove query string before matching route

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -208,7 +208,8 @@ fn read_all(readable: &mut impl Read) -> io::Result<Vec<u8>> {
 
 fn matches_to_route(route: String, path: String) -> (bool, HashMap<String, String>) {
     let route = route.split('/').filter(|el| el != &"");
-    let path = path.split('/').filter(|el| el != &"");
+    let path = path.split('?').next().unwrap()
+                   .split('/').filter(|el| el != &"");
 
     if route.clone().count() != path.clone().count() {
         return (false, HashMap::new());


### PR DESCRIPTION
As the query part of a URL is not constant, it cannot be matched exactly against route components and the server always fails to route requests with queries in them.  For example, 'http://host/css?file=test' will not match '/css', but 'http://host/css' will.

* server.rs: add extra filter in match_to_route function.