### PR TITLE
Add server lifetimes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,12 +72,12 @@ pub use server::HttpServer;
 pub use server::RequestHandler;
 
 /// Create new instance of HttpServer
-pub fn new() -> HttpServer {
+pub fn new<'a>() -> HttpServer<'a> {
     HttpServer::new()
 }
 
 /// Create new instance of HttpServer with predefined body
-pub fn create_server(default_repsonse: Response) -> HttpServer {
+pub fn create_server<'a>(default_repsonse: Response) -> HttpServer<'a> {
     let mut ret = HttpServer::new();
     ret.default_repsonse = default_repsonse;
     ret


### PR DESCRIPTION
Adds lifetimes to the server so that passed or captured parameters don't have to be static (they just have to live as long as the server).

I'm new to rust, so this may not be the correct approach. It seemed to work okay in my (admittedly limited) testing, but I'd appreciate input if there's a better or more correct approach.
